### PR TITLE
修复当相邻几个坐标点y值相同时，图标曲线会不展示bug

### DIFF
--- a/asset/smooth.html
+++ b/asset/smooth.html
@@ -19,7 +19,13 @@
             return Math.sqrt(this.x * this.x + this.y * this.y);
         },
         "normalize": function () {
-            var inv = 1 / this.length();
+            var len = this.length(),
+                inv = 0;
+            if (len === 0) {
+                inv = 0;
+            } else {
+                inv = 1/len;
+            }
             return new Vector2(this.x * inv, this.y * inv);
         },
         "add": function (v) {


### PR DESCRIPTION
测试坐标点如：
```javascript
var data = [{
                date: '01-15',
                x: 10,
                y: 120 
            },
            {
                date: '01-16',
                x: 30,
                y: 130 
            },
            {
                date: '01-17',
                x: 50,
                y: 100 
            },
            {
                date: '01-18',
                x: 70,
                y: 120 
            },
            {
                date: '01-19',
                x: 90,
                y: 130 
            },
            {
                date: '01-20',
                x: 110,
                y: 105
            },
            {
                date: '01-21',
                x: 130,
                y: 105 
            },
            {
                date: '01-22',
                x: 150,
                y: 105
            }]
```